### PR TITLE
Show icons for resources, flex list height

### DIFF
--- a/osm-community-index/index.html
+++ b/osm-community-index/index.html
@@ -9,21 +9,26 @@
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css' rel='stylesheet' />
     <style>
         body { margin:0; padding:0; }
-        h2, h3 {
+        h2 {
             margin: 10px;
             font-size: 1.2em;
         }
-        h3 {
-            font-size: 1em;
-        }
-        p {
-            font-size: 0.85em;
+        .resource {
             margin: 10px;
-            text-align: left;
+            font-size: 1em;
+            display: flex;
+            flex-flow: row nowrap;
+            align-items: center;
+        }
+        .resource .icon {
+            width: 24px;
+        }
+        .resource .label {
+            margin-left: 8px;
         }
         .map-overlay {
             position: absolute;
-            bottom: 0;
+            top: 0;
             right: 0;
             background: rgba(255, 255, 255, 0.8);
             margin-right: 20px;
@@ -39,9 +44,8 @@
         }
         #features {
             top: 0;
-            height: 250px;
             margin-top: 20px;
-            width: 250px;
+            width: 350px;
         }
 
     </style>
@@ -49,7 +53,7 @@
 <body>
 
 <div id='map'></div>
-<div class='map-overlay' id='features'><h2>OSM Communities</h2><div id='pd'><p></p></div></div>
+<div class='map-overlay' id='features'><h2>OSM Communities</h2><div id='pd'></div></div>
 
 <script>
 
@@ -60,8 +64,8 @@ mapboxgl.accessToken = 'pk.eyJ1IjoibWlrZWxtYXJvbiIsImEiOiJjaWZlY25lZGQ2cTJjc2trb
 var map = new mapboxgl.Map({
     container: 'map', // container id
     style: 'mapbox://styles/mikelmaron/ck0fhxqle2mo31ctas0153djr',
-    center: [0,0], 
-    zoom: 1 
+    center: [0,0],
+    zoom: 1
 });
 
 // wait for map to load before adjusting it
@@ -70,7 +74,7 @@ map.on('load', function() {
     // make a pointer cursor
     map.getCanvas().style.cursor = 'default';
 
-    // change info window on hover
+    // change info window on click
     map.on('click', function (e) {
         var communities  = map.queryRenderedFeatures(e.point, {
             layers: ['osm-community-index']
@@ -81,7 +85,12 @@ map.on('load', function() {
           for (var p in c['properties']) {
             try {
               var community = JSON.parse(c['properties'][p]);
-              inner += "<h3><strong><a href='" + community['url'] + "'>" + community['name'] + "</a></strong></h3>";
+              var iconURL = 'https://cdn.jsdelivr.net/gh/osmlab/osm-community-index@master/dist/img/' + community.type + '.svg';
+
+              inner += '<div class="resource">'
+                + '<img class="icon" src="' + iconURL + '"/>'
+                + '<a class="label" target="_blank" href="' + community.url + '">' + community.name + '</a>'
+                + '</div>';
             } catch(Err) {
             }
           }


### PR DESCRIPTION
Love this demo site @mikelmaron  👏 

This PR:
* shows the icons for each resource and 
* makes the height of the overlay flexible to fit the content.

<img width="426" alt="Screenshot 2019-10-22 15 25 05" src="https://user-images.githubusercontent.com/38784/67324113-4ee59b00-f4e1-11e9-8bd8-9b67d3aa21cc.png">
