### PR TITLE
Update to v1, sort communities by size and desired order

### DIFF
--- a/osm-community-index/index.html
+++ b/osm-community-index/index.html
@@ -60,53 +60,76 @@
 // define access token
 mapboxgl.accessToken = 'pk.eyJ1IjoibWlrZWxtYXJvbiIsImEiOiJjaWZlY25lZGQ2cTJjc2trbmdiZDdjYjllIn0.Wx1n0X7aeCQyDTnK6_mrGw';
 
-//create map
+// create map
 var map = new mapboxgl.Map({
-    container: 'map', // container id
-    style: 'mapbox://styles/mapbox/light-v10',
-    center: [0,0],
-    zoom: 1
+  container: 'map',
+  style: 'mapbox://styles/mapbox/light-v10',
+  center: [0,0],
+  zoom: 1
 });
+
 
 // wait for map to load before adjusting it
 map.on('load', function() {
+  var previous = '';
+  var dataURL = 'https://cdn.jsdelivr.net/npm/osm-community-index@1/dist/combined.min.geojson';
 
-    var dataURL = 'https://cdn.jsdelivr.net/npm/osm-community-index@1/dist/combined.min.geojson';
-    map.addSource('osm-community-index', { type: 'geojson', data: dataURL });
-    map.addLayer({
-      'id': 'osm-community-index',
-      'type': 'fill',
-      'source': 'osm-community-index',
-      'paint': { 'fill-color': 'hsla(243, 93%, 64%, 0.24)', 'fill-opacity': 1 }
+  map.addSource('osm-community-index', { type: 'geojson', data: dataURL });
+  map.addLayer({
+    'id': 'osm-community-index',
+    'type': 'fill',
+    'source': 'osm-community-index',
+    'paint': { 'fill-color': 'hsla(243, 93%, 64%, 0.24)', 'fill-opacity': 1 }
+  });
+
+  // make a pointer cursor
+  map.getCanvas().style.cursor = 'default';
+
+  // change info window on click
+  map.on('click', function (e) {
+    var communities = [];
+    var hits = map.queryRenderedFeatures(e.point, { layers: ['osm-community-index'] });
+
+    // gather the communities from the result
+    hits.forEach(function(hit) {
+      var props = hit.properties || {};
+      var resources = {};
+      try {
+        resources = JSON.parse(props.resources || '{}');
+      } catch (e) { }
+
+      for (var k in resources) {
+        var community = resources[k];
+        communities.push({
+          'area': props.area || Infinity,
+          'order': community.order || 0,
+          'community': community
+        });
+      }
     });
 
-    // make a pointer cursor
-    map.getCanvas().style.cursor = 'default';
-
-    // change info window on click
-    map.on('click', function (e) {
-        var communities  = map.queryRenderedFeatures(e.point, {
-            layers: ['osm-community-index']
-        });
-
-        var inner = '';
-        communities.forEach(function(c) {
-          for (var p in c['properties']) {
-            try {
-              var community = JSON.parse(c['properties'][p]);
-              var iconURL = 'https://cdn.jsdelivr.net/npm/osm-community-index@1/dist/img/' + community.type + '.svg';
-
-              inner += '<div class="resource">'
-                + '<img class="icon" src="' + iconURL + '"/>'
-                + '<a class="label" target="_blank" href="' + community.url + '">' + community.name + '</a>'
-                + '</div>';
-            } catch(Err) {
-            }
-          }
-        });
-
-        document.getElementById('pd').innerHTML = inner;
+    // sort by feature area ascending, community order descending
+    communities.sort(function(a, b) {
+      return a.area - b.area || b.order - a.order;
     });
+
+    // display
+    var inner = '';
+    communities.forEach(function(c) {
+      var community = c.community;
+      var iconURL = 'https://cdn.jsdelivr.net/npm/osm-community-index@1/dist/img/' + community.type + '.svg';
+
+      inner += '<div class="resource">'
+        + '<img class="icon" src="' + iconURL + '"/>'
+        + '<a class="label" target="_blank" href="' + community.url + '">' + community.name + '</a>'
+        + '</div>';
+    });
+
+    if (inner !== previous) {
+      previous = inner;
+      document.getElementById('pd').innerHTML = inner;
+    }
+  });
 
 });
 
@@ -114,4 +137,3 @@ map.on('load', function() {
 
 </body>
 </html>
-

--- a/osm-community-index/index.html
+++ b/osm-community-index/index.html
@@ -71,7 +71,7 @@ var map = new mapboxgl.Map({
 // wait for map to load before adjusting it
 map.on('load', function() {
 
-    var dataURL = 'https://cdn.jsdelivr.net/gh/osmlab/osm-community-index@release/dist/combined.min.geojson';
+    var dataURL = 'https://cdn.jsdelivr.net/npm/osm-community-index@1/dist/combined.min.geojson';
     map.addSource('osm-community-index', { type: 'geojson', data: dataURL });
     map.addLayer({
       'id': 'osm-community-index',
@@ -94,7 +94,7 @@ map.on('load', function() {
           for (var p in c['properties']) {
             try {
               var community = JSON.parse(c['properties'][p]);
-              var iconURL = 'https://cdn.jsdelivr.net/gh/osmlab/osm-community-index@release/dist/img/' + community.type + '.svg';
+              var iconURL = 'https://cdn.jsdelivr.net/npm/osm-community-index@1/dist/img/' + community.type + '.svg';
 
               inner += '<div class="resource">'
                 + '<img class="icon" src="' + iconURL + '"/>'


### PR DESCRIPTION
I released [v1.0.0](https://github.com/osmlab/osm-community-index/releases/tag/v1.0.0) of the community index today!  🎊 

This PR contains the changes to
- Fetch the current version (1.x) from jsdelivr CDN
- The format of `combined.geojson` has changed slightly, so this code handles the updated version that now includes the `area` property.
- Sort communities by `area` ascending, `order` descending (like what iD does)
    
 In other words:
- small areas first, large areas last
- then uses the `order` property (if set) to control the sort order within a single area
